### PR TITLE
Basic method generation initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ The following is an example of the usage applied to the test server provided und
 After performing the above steps, run the followings:
 
  1. Run the test server by `node test-env/server/server.js &`.
- *  Copy `LoopBack.framework` into `test-env/CodeGenTest/`.
+ *  Copy `LoopBack.framework` into `test-env/CodeGenTest/`,
+    where `LoopBack.framework` is the one generated from 
+    the latest [iOS SDK](https://github.com/strongloop/loopback-sdk-ios).
  *  Start xcode from `test-env/CodeGenTest/CodeGenTest.xcodeproj`.
  *  Run the CodeGenTests unit tests.
 

--- a/lib/objc-codegen.js
+++ b/lib/objc-codegen.js
@@ -48,6 +48,7 @@ function describeModels(app) {
   }
   app.handler('rest').adapter.getClasses().forEach(function(c) {
     var name = c.name;
+    var modelDefinition = app.models[name].definition;
 
     if (!c.ctor) {
       // Skip classes that don't have a shared ctor
@@ -55,11 +56,6 @@ function describeModels(app) {
       console.error('Skipping %j as it is not a LoopBack model', name);
       return;
     }
-    c.methods.forEach(function fixArgsOfPrototypeMethods(method) {
-      var ctor = method.restClass.ctor;
-      if (!ctor || method.sharedMethod.isStatic) return;
-      method.accepts = ctor.accepts.concat(method.accepts);
-    });
 
     // Skip the User class as its Obj-C implementation is provided as a part of the SDK framework.
     var isUser = c.sharedClass.ctor.prototype instanceof app.loopback.User ||
@@ -69,20 +65,25 @@ function describeModels(app) {
     }
 
     c.pluralName = c.sharedClass.ctor.pluralModelName;
-    c.params =  app.models[c.name].definition.properties;
-    c.baseModel = app.models[c.name].definition.settings.base;
-
+    c.props = modelDefinition.properties;
+    c.baseModel = modelDefinition.settings.base;
     if (c.baseModel != null && typeof(c.baseModel) === 'function') {
       c.baseModel = '';
     }
-    if (app.models[c.name].definition._ids != null) {
-      c.isGenerated = app.models[c.name].definition._ids[0].property.generated;
+    if (modelDefinition._ids != null) {
+      c.isGenerated = modelDefinition._ids[0].property.generated;
     } else {
       c.isGenerated = false;
     }
-    c.relations = app.models[c.name].definition.settings.relations;
-    c.acls = app.models[c.name].definition.settings.acls;
-    c.validations = app.models[c.name].definition.settings.validations;
+    c.relations = modelDefinition.settings.relations;
+    c.acls = modelDefinition.settings.acls;
+    c.validations = modelDefinition.settings.validations;
+
+    c.methods.forEach(function fixArgsOfPrototypeMethods(method) {
+      var ctor = method.restClass.ctor;
+      if (!ctor || method.sharedMethod.isStatic) return;
+      method.accepts = ctor.accepts.concat(method.accepts);
+    });
 
     result[name] = c;
   });
@@ -187,33 +188,208 @@ function findModelByName(models, name) {
   }
 }
 
+var methodNamesToSkip = [
+  // The followings are pre-implemented in LBPersistedModel.
+  'create',
+  'upsert',
+  'deleteById',
+  // The followings are to be supported.
+  'createChangeStream',
+  'prototype.updateAttributes'
+];
+
+var objcMethodNamesToSkip = [
+  // The following is skipped since `updateAll` invocation fails with an empty `where` argument
+  // and there is no way to provide a working implementation for it.
+  'updateAllWithData'
+];
+
+// Amend auto-generated method names which don't sound right.
+var methodNameReplacementTable = {
+  'findByIdWithId':     'findById',
+  'findWithSuccess':    'allWithSuccess',
+  'updateAllWithWhere': 'updateAllWithWhereFilter',
+  'countWithWhere':     'countWithWhereFilter'
+};
+
+// Type declaration conversion table for properties.
+// To list all the conversion rules in a uniform manner, `<...>` notation is introduced.
+var propTypeConversionTable = {
+  'String':  '(nonatomic, copy) NSString *',
+  'Number':  'NSInteger ',
+  'Boolean': 'BOOL ',
+  '<array>': '(nonatomic) NSArray *'
+};
+
+// Type conversion table for arguments.
+// To list all the conversion rules in a uniform manner, `<...>` notation is introduced.
+var argTypeConversionTable = {
+  'object data': '<objcModelType>', // Special case: the argument whose type is `object` and name is `data`.
+  'object':      'NSDictionary *',
+  'any':         'id'
+}
+
+// Return type to Obj-C success block type conversion table.
+// To list all the conversion rules in a uniform manner, `<...>` notation is introduced.
+var successBlockTypeConversionTable = {
+  '<modelName>': '<objcModelName>ObjectSuccessBlock',
+  'number':      'LBPersistedModelNumberSuccessBlock',
+  'boolean':     'LBPersistedModelBoolSuccessBlock',
+  '<array>':     'LBPersistedModelArraySuccessBlock',
+  '<void>':      'LBPersistedModelVoidSuccessBlock'
+};
+
 function addObjCNames(models, modelPrefix) {
   for (var modelName in models) {
     var meta = models[modelName];
     meta.objcModelName = modelPrefix + pascalCase(modelName);
+    meta.objcRepoName = meta.objcModelName + 'Repository';
     if (meta.baseModel === 'Model' || meta.baseModel === 'PersistedModel') {
       meta.objcBaseModel = 'LB' + meta.baseModel;
     } else {
-      throw new Error('Unknown base model: ' + meta.baseModel + ' for model: ' + modelName);
+      throw new Error('Unknown base model: "' + meta.baseModel + '" for model: "' + modelName + '"');
+    }
+    meta.objcProps = [];
+    for (var propName in meta.props) {
+      if (propName === 'id') {
+        // `_id` is already defined in LBPersistedModel
+        continue;
+      }
+      var prop = meta.props[propName];
+      var objcProp = convertToObjCPropType(prop.type);
+      if (typeof objcProp === 'undefined') {
+        throw new Error('Unsupported property type: "' + prop.type.name + '" in model: "' + modelName + '"');
+      }
+      meta.objcProps.push({name: propName, type: objcProp})
     }
 
-    meta.objcParams = [];
-    for (var param in meta.params) {
-      var type = meta.params[param].type;
-      var name = type.name;
-      if (name === 'String') {
-        meta.params[param].type.objcName = '(nonatomic, copy) NSString *';
-      } else if (name === 'Number') {
-        meta.params[param].type.objcName = 'long ';
-      } else if (name === 'Boolean') {
-        meta.params[param].type.objcName = 'BOOL ';
-      } else if (Array.isArray(type)) {
-        meta.params[param].type.objcName = '(nonatomic) NSArray *';
+    meta.objcMethods = [];
+    meta.methods.forEach(function(method) {
+      addObjCMethodInfo(meta, method, modelName, true);
+      if (hasOptionalArguments(method)) {
+        addObjCMethodInfo(meta, method, modelName, false);
+      }
+    });
+  }
+}
+
+function addObjCMethodInfo(meta, method, modelName, skipOptionalArguments) {
+  if (methodNamesToSkip.indexOf(method.name) >= 0) {
+    return;
+  }
+  var methodPrototype = '';
+  var methodName = method.name;
+  var paramAssignments;
+  var bodyParamAssignments;
+  method.accepts.forEach(function (param) {
+    var paramRequired = param.required || (param.http && param.http.source === 'body');
+    if (!paramRequired && skipOptionalArguments) {
+      return;
+    }
+    var objcModelType = meta.objcModelName + ' *';
+    var argType = convertToObjCArgType(param.type, param.arg, objcModelType);
+    if (typeof argType === 'undefined') {
+      throw new Error('Unsupported argument type: "' + param.type + '" in model: "' + modelName + '"');
+    }
+    var argName = (param.arg === 'id') ? 'id_' : param.arg;
+    var argRightValue = argName;
+    if (argType === objcModelType) {
+      argRightValue = '[' + param.arg + ' toDictionary]';
+    } else if (argType === 'NSDictionary *') {
+      argRightValue = '(' + param.arg + ' ? ' + param.arg + ' : @{})';
+    }
+    if (methodName === method.name) {
+      methodName += 'With' + param.arg[0].toUpperCase() + param.arg.slice(1);
+    } else {
+      methodPrototype += ' ' + param.arg;
+    }
+    if (param.http && param.http.source === 'body') {
+      if (bodyParamAssignments) {
+        throw new Error('Multiple body arguments specified in method: "' + method.name + '" of model: "' + modelName + '"');
+      }
+      bodyParamAssignments = argRightValue;
+    } else {
+      if (!paramAssignments) {
+        paramAssignments = '@"' + param.arg + '": ' + argRightValue;
       } else {
-        throw new Error('Unsupported parameter type: ' + name + ' in model: ' + modelName);
+        paramAssignments += ', @"' + param.arg + '": ' + argRightValue;
       }
     }
+
+    methodPrototype += ':(' + argType + ')' + argName;
+  });
+
+  var returnArg = method.returns[0] && method.returns[0].arg;
+  var returnType = method.returns[0] && method.returns[0].type;
+  var successBlockType = convertToObjCSuccessBlockType(returnType, modelName, meta.objcModelName);
+  if (typeof successBlockType === 'undefined') {
+    throw new Error('Unsupported return type: "' + returnType + '" in model: "' + modelName + '"');
   }
+
+  if (methodName === method.name) {
+    methodName += 'WithSuccess';
+    methodPrototype += ':(' + successBlockType + ')success ';
+  } else {
+    methodPrototype += '\n        success:(' + successBlockType + ')success';
+  }
+  methodPrototype   += '\n        failure:(SLFailureBlock)failure';
+
+  if (objcMethodNamesToSkip.indexOf(methodName) >= 0) {
+    return;
+  }
+  if (methodNameReplacementTable[methodName]) {
+    methodName = methodNameReplacementTable[methodName];
+  }
+  methodPrototype = '(void)' + methodName + methodPrototype;
+
+  meta.objcMethods.push({
+    rawName: method.name,
+    prototype: methodPrototype,
+    returnArg: returnArg,
+    successBlockType: successBlockType,
+    paramAssignments: paramAssignments,
+    bodyParamAssignments: bodyParamAssignments
+  });
+  method.objcGenerated = true;
+}
+
+function hasOptionalArguments(method) {
+  for (var idx in method.accepts) {
+    var param = method.accepts[idx];
+    var paramRequired = param.required || (param.http && param.http.source === 'body');
+    if (!paramRequired) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function convertToObjCPropType(type) {
+  if (Array.isArray(type)) {
+    return propTypeConversionTable['<array>'];
+  }
+  return propTypeConversionTable[type.name];
+}
+
+function convertToObjCArgType(type, name, objcModelType) {
+  var objcType = argTypeConversionTable[type + ' ' + name];
+  objcType = objcType || argTypeConversionTable[type];
+
+  return objcType.replace('<objcModelType>', objcModelType);
+}
+
+function convertToObjCSuccessBlockType(type, modelName, objcModelName) {
+  if (typeof type === 'undefined') {
+    type = '<void>';
+  }
+  if (Array.isArray(type)) {
+    type = '<array>';
+  }
+  if (type === modelName) {
+    type = '<modelName>';
+  }
+  var blockType = successBlockTypeConversionTable[type];
+  return blockType.replace('<objcModelName>', objcModelName);
 }
 
 function readTemplate(filename) {

--- a/lib/objc-model-h.ejs
+++ b/lib/objc-model-h.ejs
@@ -1,17 +1,16 @@
 //
-// <%-: meta.objcModelName %>.h
+// <%- meta.objcModelName %>.h
 //
 
 #import <LoopBack/LoopBack.h>
 
-@interface <%-: meta.objcModelName %> : <%-:meta.objcBaseModel %>
+@interface <%- meta.objcModelName %> : <%- meta.objcBaseModel %>
 
-<% for (var param in meta.params) {
-     if (param === 'id') {
-       continue;
-     }
+<% meta.objcProps.forEach(function(prop) {
 -%>
-@property <%-: meta.params[param].type.objcName %><%-: param %>;
-<% }; -%>
+@property <%- prop.type %><%- prop.name %>;
+<%
+   });
+-%>
 
 @end

--- a/lib/objc-model-m.ejs
+++ b/lib/objc-model-m.ejs
@@ -1,9 +1,9 @@
 //
-// <%-: meta.objcModelName %>.m
+// <%- meta.objcModelName %>.m
 //
 
-#import "<%-: meta.objcModelName %>.h"
+#import "<%- meta.objcModelName %>.h"
 
-@implementation <%-: meta.objcModelName %>
+@implementation <%- meta.objcModelName %>
 
 @end

--- a/lib/objc-repo-h.ejs
+++ b/lib/objc-repo-h.ejs
@@ -1,11 +1,20 @@
 //
-// <%-: meta.objcModelName %>Repository.h
+// <%- meta.objcRepoName %>.h
 //
 
-#import <LoopBack/LoopBack.h>
+#import "<%- meta.objcModelName %>.h"
 
-@interface <%-: meta.objcModelName %>Repository : <%-:meta.objcBaseModel %>Repository
+typedef void (^<%- meta.objcModelName %>ObjectSuccessBlock)(<%- meta.objcModelName %> *model);
 
-+ (instancetype)repository;
+@interface <%- meta.objcRepoName %> : <%- meta.objcBaseModel %>Repository
+
+- (<%- meta.objcModelName %> *)modelWithDictionary:(NSDictionary *)dictionary;
+
+<% meta.objcMethods.forEach(function(method) {
+-%>
+- <%- method.prototype %>;
+<%
+   });
+-%>
 
 @end

--- a/lib/objc-repo-m.ejs
+++ b/lib/objc-repo-m.ejs
@@ -1,13 +1,66 @@
 //
-// <%-: meta.objcModelName %>Repository.m
+// <%- meta.objcRepoName %>.m
 //
 
-#import "<%-: meta.objcModelName %>Repository.h"
+#import "<%- meta.objcRepoName %>.h"
 
-@implementation <%-:meta.objcModelName %>Repository
+@implementation <%- meta.objcRepoName %>
 
 + (instancetype)repository {
-    return [self repositoryWithClassName:@"<%-: meta.pluralName  %>"];
+    return [self repositoryWithClassName:@"<%- meta.pluralName %>"];
 }
+
+- (<%- meta.objcModelName %> *)modelWithDictionary:(NSDictionary *)dictionary {
+    return (<%- meta.objcModelName %> *)[super modelWithDictionary:dictionary];
+}
+
+- (SLRESTContract *)contract {
+    SLRESTContract *contract = [super contract];
+
+<% meta.methods.forEach(function (method) {
+     if (method.objcGenerated) {
+-%>
+    [contract addItem:[SLRESTContractItem itemWithPattern:[NSString stringWithFormat:@"/%@<%- method.routes[0].path %>", self.className]
+                                                     verb:@"<%- method.routes[0].verb.toUpperCase() %>"]
+            forMethod:[NSString stringWithFormat:@"%@.<%- method.name %>", self.className]];
+<%   }
+   });
+-%>
+
+    return contract;
+}
+
+<% meta.objcMethods.forEach(function(method) { -%>
+
+- <%- method.prototype %> {
+     [self invokeStaticMethod:@"<%- method.rawName %>"
+                   parameters:@{ <%- method.paramAssignments %> }
+<%   if (method.bodyParamAssignments) { -%>
+               bodyParameters:<%- method.bodyParamAssignments %>
+<%   } -%>
+                      success:^(id value) {
+<%   if (method.successBlockType === meta.objcModelName + 'ObjectSuccessBlock') { -%>
+                        NSAssert([[value class] isSubclassOfClass:[NSDictionary class]], @"Received non-Dictionary: %@", value);
+                        success((<%- meta.objcModelName %>*)[self modelWithDictionary:value]);
+<%   } else if (method.successBlockType === 'LBPersistedModelArraySuccessBlock') { -%>
+                        NSAssert([[value class] isSubclassOfClass:[NSArray class]], @"Received non-Array: %@", value);
+                        NSMutableArray *models = [NSMutableArray array];
+                        [value enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                            [models addObject:[self modelWithDictionary:obj]];
+                        }];
+                        success(models);
+<%   } else if (method.successBlockType === 'LBPersistedModelBoolSuccessBlock') { -%>
+                        success(((NSNumber *)value[@"<%- method.returnArg %>"]).boolValue);
+<%   } else if (method.successBlockType === 'LBPersistedModelNumberSuccessBlock') { -%>
+                        success(((NSNumber *)value[@"<%- method.returnArg %>"]).integerValue);
+<%   } else if (method.successBlockType === 'LBPersistedModelVoidSuccessBlock') { -%>
+                        success();
+<%   } -%>
+                      }
+                      failure:failure];
+}
+<%
+   });
+-%>
 
 @end

--- a/test-env/server/boot/root.js
+++ b/test-env/server/boot/root.js
@@ -1,0 +1,6 @@
+module.exports = function(server) {
+  // Install a `/` route that returns server status
+  var router = server.loopback.Router();
+  router.get('/', server.loopback.status());
+  server.use(router);
+};


### PR DESCRIPTION
This PR requires https://github.com/strongloop/loopback-sdk-ios/pull/68

Because of the Obj-C's conventions and such, the following decisions are made:
- In Obj-C mapping, `create`, `upsert` and `deleteById` are implemented as instance methods (following object oriented approach) rather than being methods of the repository.  Those methods are pre-implemented in LBPersistedModel and not generated.
- The following methods are to be supported:
  `createChangeStream`,
  `prototype.updateAttributes`
- `updateAllWithData` method generation (`updateAll` with `data` argument only) is skipped since `updateAll` invocation fails with an empty `where` argument and there is no way to provide a working implementation for it.
- The following auto-generated method names are amended to sound better:
  `findByIdWithId`     -> `findById`
  `findWithSuccess`    -> `allWithSuccess`
  `updateAllWithWhere` -> `updateAllWithWhereFilter`
  `countWithWhere`     -> `countWithWhereFilter`
- Since there is no good way to express optional arguments in Obj-C, those methods that have optional (non-required) arguments are converted into a method without optional argument and one with optionals.  For example, `findOne` method is converted into `findOneWithSuccess:failure:` and `findOneWithFilter:success:failure:`.

@bajtos @raymondfeng , would you please review the changes?
