### PR TITLE
Fix Issue #8 -- a bug in number treatment and compile time warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The following is an example usage applied to the test server provided under this
 
 After performing the above steps, run the followings:
 
- 1. Run the test server by `node test-env/server/server.js &`.
- *  `cd` into `test-env/client/ios/CodeGenTest`.
- *  Setup the test environment using **CocoaPods**: `pod install`.
- *  Start xcode from `CodeGenTest.xcworkspace`.
+ 1. `node test-env/server/server.js`
+ *  `cd test-env/client/ios/CodeGenTest`
+ *  `pod install`
+ *  `open CodeGenTest.xcworkspace`
  *  Run the CodeGenTestTests unit tests.
 
 

--- a/lib/objc-codegen.js
+++ b/lib/objc-codegen.js
@@ -216,7 +216,7 @@ var methodNameReplacementTable = {
 // To list all the conversion rules in a uniform manner, `<...>` notation is introduced.
 var propTypeConversionTable = {
   'String':  '(nonatomic, copy) NSString *',
-  'Number':  'NSInteger ',
+  'Number':  'NSNumber *',
   'Boolean': 'BOOL ',
   '<array>': '(nonatomic) NSArray *'
 };
@@ -229,15 +229,13 @@ var argTypeConversionTable = {
   'any':         'id'
 }
 
-// Return type to Obj-C success block type conversion table.
-// To list all the conversion rules in a uniform manner, `<...>` notation is introduced.
-var successBlockTypeConversionTable = {
-  '<modelName>': '<objcModelName>ObjectSuccessBlock',
-  'object':      'LBPersistedModelDictionarySuccessBlock',
-  'number':      'LBPersistedModelNumberSuccessBlock',
-  'boolean':     'LBPersistedModelBoolSuccessBlock',
-  '<array>':     'LBPersistedModelArraySuccessBlock',
-  '<void>':      'LBPersistedModelVoidSuccessBlock'
+// Return type to Obj-C return type conversion table.
+var returnTypeConversionTable = {
+  'object':   'NSDictionary',
+  'number':   'NSNumber',
+  'boolean':  'BOOL',
+  '<array>':  'NSArray',
+  '<void>':   'void'
 };
 
 function addObjCNames(models, modelPrefix, verbose) {
@@ -335,12 +333,13 @@ function addObjCMethodInfo(meta, method, modelName, skipOptionalArguments) {
 
   var returnArg = method.returns[0] && method.returns[0].arg;
   var returnType = method.returns[0] && method.returns[0].type;
-  var successBlockType = convertToObjCSuccessBlockType(returnType, modelName, meta.objcModelName);
-  if (typeof successBlockType === 'undefined') {
+  var objcReturnType = convertToObjCReturnType(returnType, modelName, meta.objcModelName);
+  if (typeof objcReturnType === 'undefined') {
     throw new Error(
       'Unsupported return type: "' + returnType + '" in method: "' + method.name +
       '" of model: "' + modelName + '"');
   }
+  var successBlockType = convertToObjCSuccessBlockType(objcReturnType);
 
   if (methodName === method.name) {
     methodName += 'WithSuccess';
@@ -362,7 +361,7 @@ function addObjCMethodInfo(meta, method, modelName, skipOptionalArguments) {
     rawName: method.name,
     prototype: methodPrototype,
     returnArg: returnArg,
-    successBlockType: successBlockType,
+    objcReturnType: objcReturnType,
     paramAssignments: paramAssignments,
     bodyParamAssignments: bodyParamAssignments
   });
@@ -396,21 +395,29 @@ function convertToObjCArgType(type, name, objcModelType) {
   return objcType;
 }
 
-function convertToObjCSuccessBlockType(type, modelName, objcModelName) {
+function convertToObjCReturnType(type, modelName, objcModelName) {
+  if (type === modelName) {
+    return objcModelName;
+  }
   if (typeof type === 'undefined') {
     type = '<void>';
   }
   if (Array.isArray(type)) {
     type = '<array>';
   }
-  if (type === modelName) {
-    type = '<modelName>';
+  return returnTypeConversionTable[type];
+}
+
+function convertToObjCSuccessBlockType(objcType) {
+  var returnArgType;
+  if (objcType === 'void') {
+    returnArgType = '';
+  } else if (objcType === 'BOOL') { // primitive type
+    returnArgType = objcType;
+  } else {
+    returnArgType = objcType + ' *';
   }
-  var blockType = successBlockTypeConversionTable[type];
-  if (blockType) {
-    blockType = blockType.replace('<objcModelName>', objcModelName);
-  }
-  return blockType;
+  return 'void (^)(' + returnArgType + ')';
 }
 
 function readTemplate(filename) {

--- a/lib/objc-repo-h.ejs
+++ b/lib/objc-repo-h.ejs
@@ -4,11 +4,6 @@
 
 #import "<%- meta.objcModelName %>.h"
 
-typedef void (^<%- meta.objcModelName %>ObjectSuccessBlock)(<%- meta.objcModelName %> *model);
-
-// TODO: to be moved to LBPersistedModel.h
-typedef void (^LBPersistedModelDictionarySuccessBlock)(NSDictionary *dictionary);
-
 @interface <%- meta.objcRepoName %> : <%- meta.objcBaseModel %>Repository
 
 - (<%- meta.objcModelName %> *)modelWithDictionary:(NSDictionary *)dictionary;

--- a/lib/objc-repo-m.ejs
+++ b/lib/objc-repo-m.ejs
@@ -39,24 +39,24 @@
                bodyParameters:<%- method.bodyParamAssignments %>
 <%   } -%>
                       success:^(id value) {
-<%   if (method.successBlockType === meta.objcModelName + 'ObjectSuccessBlock') { -%>
-                        NSAssert([[value class] isSubclassOfClass:[NSDictionary class]], @"Received non-Dictionary: %@", value);
+<%   if (method.objcReturnType === meta.objcModelName) { -%>
+                        NSAssert([value isKindOfClass:[NSDictionary class]], @"Received non-Dictionary: %@", value);
                         success((<%- meta.objcModelName %>*)[self modelWithDictionary:value]);
-<%   } else if (method.successBlockType === 'LBPersistedModelDictionarySuccessBlock') { -%>
-                        NSAssert([[value class] isSubclassOfClass:[NSDictionary class]], @"Received non-Dictionary: %@", value);
+<%   } else if (method.objcReturnType === 'NSDictionary') { -%>
+                        NSAssert([value isKindOfClass:[NSDictionary class]], @"Received non-Dictionary: %@", value);
                         success((NSDictionary *)value);
-<%   } else if (method.successBlockType === 'LBPersistedModelArraySuccessBlock') { -%>
-                        NSAssert([[value class] isSubclassOfClass:[NSArray class]], @"Received non-Array: %@", value);
+<%   } else if (method.objcReturnType === 'NSArray') { -%>
+                        NSAssert([value isKindOfClass:[NSArray class]], @"Received non-Array: %@", value);
                         NSMutableArray *models = [NSMutableArray array];
                         [value enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
                             [models addObject:[self modelWithDictionary:obj]];
                         }];
                         success(models);
-<%   } else if (method.successBlockType === 'LBPersistedModelBoolSuccessBlock') { -%>
+<%   } else if (method.objcReturnType === 'BOOL') { -%>
                         success(((NSNumber *)value[@"<%- method.returnArg %>"]).boolValue);
-<%   } else if (method.successBlockType === 'LBPersistedModelNumberSuccessBlock') { -%>
-                        success(((NSNumber *)value[@"<%- method.returnArg %>"]).integerValue);
-<%   } else if (method.successBlockType === 'LBPersistedModelVoidSuccessBlock') { -%>
+<%   } else if (method.objcReturnType === 'NSNumber') { -%>
+                        success(((NSNumber *)value[@"<%- method.returnArg %>"]));
+<%   } else if (method.objcReturnType === 'void') { -%>
                         success();
 <%   } -%>
                       }

--- a/test-env/bin/run-unittests
+++ b/test-env/bin/run-unittests
@@ -23,8 +23,10 @@ instruments -s devices
 
 # compile and run the unit tests
 xcodebuild \
-    -workspace CodeGenTest.xcworkspace \
-    -scheme CodeGenTest \
-    -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=iPhone Retina (4-inch 64-bit),OS=latest' \
-    clean test
+  -verbose \
+  -workspace CodeGenTest.xcworkspace \
+  -scheme CodeGenTest \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone Retina (4-inch 64-bit),OS=latest' \
+  ${XCODEBUILD_ARGS} \
+  clean test


### PR DESCRIPTION
This fixes warnings caused by the recent changes in https://github.com/strongloop/loopback-sdk-ios.

Also fix a bug in number treatment -- it used to map JS `number` to `NSInteger` mistakenly although `number` could be a float value.

@bajtos could you please review the changes?
