### PR TITLE
Ignore computed "accepts" arguments

### DIFF
--- a/lib/objc-codegen.js
+++ b/lib/objc-codegen.js
@@ -296,6 +296,11 @@ function addObjCMethodInfo(meta, method, modelName, skipOptionalArguments) {
   var paramAssignments;
   var bodyParamAssignments;
   method.accepts.forEach(function (param) {
+    // Skip arguments derived by a server-side code
+    if (isServerComputedArg(param)) {
+      return;
+    }
+
     var paramRequired = param.required || (param.http && param.http.source === 'body');
     if (!paramRequired && skipOptionalArguments) {
       return;
@@ -376,12 +381,26 @@ function addObjCMethodInfo(meta, method, modelName, skipOptionalArguments) {
 function hasOptionalArguments(method) {
   for (var idx in method.accepts) {
     var param = method.accepts[idx];
+    if (isServerComputedArg(param)) {
+      continue;
+    }
     var paramRequired = param.required || (param.http && param.http.source === 'body');
     if (!paramRequired) {
       return true;
     }
   }
   return false;
+}
+
+function isServerComputedArg(param) {
+  if (typeof param.http === 'function') {
+    return true;
+  }
+
+  var httpSource = param.http && param.http.source;
+  return httpSource === 'req' ||
+    httpSource === 'res' ||
+    httpSource === 'context';
 }
 
 function convertToObjCPropType(type) {

--- a/test-env/client/ios/CodeGenTest/CodeGenTest.xcodeproj/project.pbxproj
+++ b/test-env/client/ios/CodeGenTest/CodeGenTest.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		9A86B9E429A6B7474DC3F9C1 /* [CP] Embed Pods Frameworks */ = {
@@ -370,7 +370,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		F1E01B4ABA5E5A9760F3CC39 /* [CP] Embed Pods Frameworks */ = {


### PR DESCRIPTION
A downstream build of https://github.com/strongloop/loopback/pull/3048 discovered a bug in our iOS SDK generator where server-computed "accepts" arguments were incorrectly included in the generated client methods.

This patch is fixing the generator to skip these arguments.

The code is coming from https://github.com/strongloop/loopback-swagger/blob/7e33fcf0cd2f6f7a6ee38d169ea89013ff18c239/lib/specgen/route-helper.js#L70-L84

@strongloop/sq-lb-apex and/or @gunjpan PTAL

See also https://github.com/strongloop/loopback/issues/1495